### PR TITLE
Update fa_api.apex

### DIFF
--- a/salesforce/fa_api.apex
+++ b/salesforce/fa_api.apex
@@ -1,3 +1,12 @@
+------------------------------------
+The code refernced below was written c 2012 before named credentials in Salesforce were released in the Spring 15 release
+Named credentials allow managing authentication without a line of code.
+https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_named_credentials.htm
+
+Note that authenttication with the FormAssembly API does not return state, which is a CSRF risk, so Salesforce blocks the authentication, which prevents use of Named Credentials.  
+Hopefully this will be fixed soon.
+
+-------------------------------------
 See https://github.com/drewbuschhorn/sfdc-oauth-playground/tree/oauth2_drew
 
 Refactored for OAuth2 use with FormAsembly, but tests not refactored.


### PR DESCRIPTION
the code in this repo is from before named credentials were released in 2015.   this should no longer be necessary, though some security issues need to be addressed by formassembly.